### PR TITLE
CI: don't commit logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Fetch data and push
 on:
   push:
   schedule:
-    - cron:  '40 2 * * *'
+    - cron:  '40 2 */3 * *'
 
 jobs:
   build:
@@ -46,16 +46,12 @@ jobs:
       run: |
         python generate.py
 
-    - name: Delete old logs
-      run: |
-        find logs/ -type f -mtime +$KEEP_NB_DAYS_LOGS -exec rm -f {} \;
-
     - name: Push generated data
       if: github.ref == 'refs/heads/master'
       run: |
         git config user.email "actions@github.com"
         git config user.name "actions-user"
-        git add -f logs prod
+        git add prod
         git commit -am "New data at $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
         git push origin master
 


### PR DESCRIPTION
Follow up of #6.

I'm reverting the commit of the `logs` folder as it was suggested https://github.com/etalab/piwik-covisits/pull/6#pullrequestreview-473256933

In fact, it's not possible to commit the `logs` folder content. It's too huge to be stored in a Git repo and it took 10-15 minutes on GitHub Actions to commit - and eventually it failed.

I guess we could use an external service to store/fetch logs but I'd be in favour of running the script less often, for now, to reduce compute time.

See CI logs: https://github.com/etalab/piwik-covisits/runs/1027815352?check_suite_focus=true